### PR TITLE
Update iCub model to preserve fixed joints for ft sensors

### DIFF
--- a/gym_ignition_models/iCubGazeboV2_5/icub.urdf
+++ b/gym_ignition_models/iCubGazeboV2_5/icub.urdf
@@ -1448,6 +1448,36 @@
     <parent link="r_foot"/>
     <child link="r_foot_dh_frame"/>
   </joint>
+  <gazebo reference="r_arm_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="l_arm_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="r_leg_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="l_leg_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="r_foot_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="l_foot_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
   <gazebo reference="l_foot">
     <collision>
       <surface>


### PR DESCRIPTION
Pull request #1 added the model of the iCub humanoid robot. The model was adapted from the [icub-models](https://github.com/robotology/icub-models) repository. Before https://github.com/robotology/icub-model-generator/pull/129 (read discussion in https://github.com/robotology/gym-ignition/issues/130), when the URDF was converted to SDF, the fixed joints of the upstream model used for the robot's FT sensors were transformed to revolute joints with limits that did not allow any movement. This workaround way due to the lack of SDF support of fixed joints. Since we were not interested to have those joints in our models, they have been removed in 7ca06009f840f3e764be3a687f0db0a093182c62.

Recent version of SDFormat included fixed joints support, and the upstream iCub model has been updated accordingly. This PR adds again the FT fixed joints to the model of this repository.

Note that this PR solves few minor issues we had in this days:

1. The frames `{r,l}_forearm` and `{r,l}_foot` are back (before links were lumped together)
1. The gym-ignition method `RobotJoints.joint_names()` still do not have the fixed `_ft_` joints (instead, using the previous upstream model, those joints were listed since they were transformed to revolute joints in the resulting SDF and gym-ignition treated them as regular revolute joints)