### PR TITLE
Add end effector frame to Panda arm

### DIFF
--- a/gym_ignition_models/panda/panda.urdf
+++ b/gym_ignition_models/panda/panda.urdf
@@ -332,7 +332,7 @@
     </inertial>
   </link>
   <joint name="end_effector_frame_fixed_joint" type="fixed">
-    <origin rpy="0 0 -0.785398163397" xyz="0 0 0.21"/>
+    <origin rpy="3.14159 -1.57079 -0.785398163397" xyz="0 0 0.21"/>
     <parent link="panda_link7"/>
     <child link="end_effector_frame"/>
   </joint>

--- a/gym_ignition_models/panda/panda.urdf
+++ b/gym_ignition_models/panda/panda.urdf
@@ -324,4 +324,21 @@
     <axis xyz="0 -1 0"/>
     <limit effort="20" lower="-0.001" upper="0.04" velocity="0.3"/>
   </joint>
+  <link name="end_effector_frame">
+    <inertial>
+      <!-- Dummy inertial parameters to avoid link lumping-->
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <joint name="end_effector_frame_fixed_joint" type="fixed">
+    <origin rpy="0 0 -0.785398163397" xyz="0 0 0.21"/>
+    <parent link="panda_link7"/>
+    <child link="end_effector_frame"/>
+  </joint>
+  <gazebo reference="end_effector_frame_fixed_joint">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
 </robot>


### PR DESCRIPTION
Our Panda model (#2) does not have any end effector frame, very useful for cartesian control.

This PR adds a fake link attached with a fixed joint to the `panda_link7` link:

- Position: the center of the gripper's fingers
- Orientation: X axis pointing forward, Y axis aligned with finger's prismatic joints

![panda_end_effector_frame](https://user-images.githubusercontent.com/469199/74245972-1d891900-4ce4-11ea-833e-c34a77a2a8a0.png)

Unfortunately I couldn't find a way to avoid adding a dummy mass to the fake `end_effector_frame` link. @traversaro do you have any smarter workaround?

cc @paolo-viceconte @eleramp 