### PR TITLE
Change base iCub link to have x-forward and z-upward

### DIFF
--- a/gym_ignition_models/iCubGazeboV2_5/icub.urdf
+++ b/gym_ignition_models/iCubGazeboV2_5/icub.urdf
@@ -1,4 +1,7 @@
 <robot name="iCubGazeboV2_5">
+  <gazebo>
+    <pose>0.0 0.0 0.63 0.0 0.0 0.0</pose>
+  </gazebo>
   <link name="root_link">
     <inertial>
       <origin xyz="0.0248821 0.000103947 -0.0440806"
@@ -1429,7 +1432,7 @@
   </joint>
   <link name="base_link"/>
   <joint name="base_fixed_joint" type="fixed">
-    <origin xyz="0 0 0" rpy="0 -0 0"/>
+    <origin xyz="0 0 0" rpy="0 0 3.14"/>
     <axis xyz="0 0 0"/>
     <parent link="base_link"/>
     <child link="root_link"/>
@@ -1595,9 +1598,6 @@
   </gazebo>
   <gazebo reference="neck_yaw">
     <implicitSpringDamper>1</implicitSpringDamper>
-  </gazebo>
-  <gazebo>
-    <pose>0.0 0.0 0.63 0.0 0.0 3.14</pose>
   </gazebo>
   <gazebo reference="root_link">
     <visual>


### PR DESCRIPTION
For historical reasons, the iCub model has the x axis of the base pointing backward. The upstream model uses a pose element to insert the model in gazebo with the right orientation (facing forward).

The position of the frame could be confusing to new users, especially when cartesian orientation are involved (e.g. floating base IK). This PR updates the model to have the base frame with x pointing forward.

![icub_base_link](https://user-images.githubusercontent.com/469199/75967444-1cef3700-5ecc-11ea-94ec-3eb0aa7aafbb.png)

- [Official documentation](https://github.com/robotology/icub-models#change-the-orientation-of-the-root-frame)
- https://github.com/ihmcrobotics/iCub/issues/1
- https://github.com/traversaro/idyntree/blob/358beda0c8ec74000f0778cdb602dafb5347d20b/src/model_io/urdf/include/iDynTree/ModelIO/ModelExporter.h#L85-L89