### PR TITLE
Add iCubGazeboSimpleCollisionsV2_5 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ for robot_name in m.get_robot_names():
 | `ground_plane` | <img src="https://user-images.githubusercontent.com/469199/73735685-f3fa4b80-473f-11ea-897d-28fcac85f8a6.png" height="300"> |
 | `cartpole` | <img src="https://user-images.githubusercontent.com/469199/73771326-7570ce80-477e-11ea-82bc-d160d4bb88b8.png" height="300"> |
 | `pendulum` | <img src="https://user-images.githubusercontent.com/469199/73772768-1b253d00-4781-11ea-88e7-b21340351549.png" height="300"> |
-| `iCubGazeboV2_5` | <img src="https://user-images.githubusercontent.com/469199/73731308-90205480-4738-11ea-876c-e9be502829ef.png" height="300"> |
+| `iCubGazeboV2_5` </br> `iCubGazeboSimpleCollisionsV2_5` | <img src="https://user-images.githubusercontent.com/469199/73731308-90205480-4738-11ea-876c-e9be502829ef.png" height="300"> |
 | `panda` | <img src="https://user-images.githubusercontent.com/469199/73738280-7f75db80-4744-11ea-805c-318e3b064847.png" height="300"> |
 | `character` | <img src="https://user-images.githubusercontent.com/469199/75965269-d8ae6780-5ec8-11ea-9712-605b600bf3b2.png" height="300"> |

--- a/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
+++ b/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
@@ -1,0 +1,1651 @@
+<!-- This URDF was manually generated simplifying the collision meshes of the iCubGazeboV2_5 model. -->
+<robot name="iCubGazeboSimpleCollisionsV2_5">
+  <link name="root_link">
+    <inertial>
+      <origin xyz="0.0248821 0.000103947 -0.0440806"
+              rpy="1.57079632679 0 -1.57079632679"/>
+      <mass value="5.09143"/>
+      <inertia ixx="0.0139679" ixy="-5.93488e-06" ixz="-1.55458e-05" iyy="0.0202112"
+               iyz="-0.00170968" izz="0.0249124"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.0364 0 0.032" rpy="1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.035 0 -0.065" rpy="0 0 0"/>
+      <geometry>
+    	    <box size="0.16 0.22 0.16" />
+      </geometry>
+    </collision>
+  </link>
+  <link name="r_hip_1">
+    <inertial>
+      <origin xyz="-0.0005145 -0.0380753 -7.1e-05"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.919978"/>
+      <inertia ixx="0.000404268" ixy="-1.26852e-06" ixz="1.11055e-06"
+               iyy="0.000574741" iyz="-7.69474e-07" izz="0.000580025"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428515000001 0.026 0.151913"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_hip_1_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_hip_pitch" type="revolute">
+    <origin xyz="0.0064515 0.026 -0.119913" rpy="0 0 -3.14159265359"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="root_link"/>
+    <child link="r_hip_1"/>
+    <limit effort="55.5" lower="-0.785398163397" upper="2.33874119767"
+           velocity="5.1"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_hip_2">
+    <inertial>
+      <origin xyz="-0.0009315 8.09999999998e-06 -0.044809"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.413242"/>
+      <inertia ixx="0.00046914" ixy="-4.76597e-08" ixz="7.12496e-08"
+               iyy="0.000277108" iyz="3.3401e-06" izz="0.000303891"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428514998094 0.0701 0.151913"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_hip_2_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_hip_roll" type="revolute">
+    <origin xyz="0 -0.0441 0" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 -2.22044604925e-16"/>
+    <parent link="r_hip_1"/>
+    <child link="r_hip_2"/>
+    <limit effort="37.0" lower="-0.349065850399" upper="2.09439510239"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_hip_3">
+    <inertial>
+      <origin xyz="-0.000123 -0.0002823 0.008718"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.126212"/>
+      <inertia ixx="0.01" ixy="2.67901e-07" ixz="-4.41463e-09" iyy="0.01"
+               iyz="3.32338e-08" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090152 -0.0700999919 -0.226213"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_upper_thigh_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_leg_ft_sensor" type="fixed">
+    <origin xyz="-0.0009363 1.39e-05 -0.0743" rpy="3.14159265359 0 0"/>
+    <parent link="r_hip_2"/>
+    <child link="r_hip_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_upper_leg">
+    <inertial>
+      <origin xyz="0.0034 -2.91e-05 -0.078954" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.8035"/>
+      <inertia ixx="0.00647751422999" ixy="0.000129579429588"
+               ixz="5.48205094739e-06" iyy="0.0014593786411"
+               iyz="-0.000136613086875" izz="0.00646720823813"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090152 0.0700999919 0.240813"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_thigh_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_hip_yaw" type="revolute">
+    <origin xyz="0 0 0.0144" rpy="-3.14159265359 0 0"/>
+    <axis xyz="0.0 -2.22044604925e-16 -1.0"/>
+    <parent link="r_hip_3"/>
+    <child link="r_upper_leg"/>
+    <limit effort="37.0" lower="-1.3962634016" upper="1.3962634016" velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_upper_leg_back_contact"/>
+  <joint name="r_upper_leg_back_contact_fixed_joint" type="fixed">
+    <origin xyz="-0.0511998 0 0.0146" rpy="0 1.57079632679 0"/>
+    <parent link="r_upper_leg"/>
+    <child link="r_upper_leg_back_contact"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_upper_leg_dh_frame"/>
+  <joint name="r_upper_leg_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.145825" rpy="1.57079632679 0 0"/>
+    <parent link="r_upper_leg"/>
+    <child link="r_upper_leg_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg">
+    <inertial>
+      <origin xyz="0.0012364 -0.0035131 -0.088794"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.472"/>
+      <inertia ixx="0.00423993167478" ixy="0.000228814548854"
+               ixz="-5.55646459453e-05" iyy="0.00152095043447"
+               iyz="-0.000264132979243" izz="0.00457358584206"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090152 0.070099992 0.386638"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_shank_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.005 0 -0.08"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+	    <box size="0.12 0.2 0.12" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_knee" type="revolute">
+    <origin xyz="0 0 -0.145825" rpy="0 0 0"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="r_upper_leg"/>
+    <child link="r_lower_leg"/>
+    <limit effort="37.0" lower="-2.16420827247" upper="0.0698131700798"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_ankle_1">
+    <inertial>
+      <origin xyz="0.0151436 -0.0008686 4.2e-05"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.6803"/>
+      <inertia ixx="0.000404618848932" ixy="7.49819286945e-07"
+               ixz="-3.01349467691e-05" iyy="0.000448633654664"
+               iyz="2.5726697409e-06" izz="0.000308235939139"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090152 0.070099992 0.587138"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_ankle_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_ankle_pitch" type="revolute">
+    <origin xyz="0 0 -0.2005" rpy="0 0 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_ankle_1"/>
+    <limit effort="37.0" lower="-0.610865238198" upper="0.610865238198"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_ankle_2">
+    <inertial>
+      <origin xyz="0.0011446 3.59999999999e-06 -0.03852"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.265122"/>
+      <inertia ixx="0.01" ixy="-4.74606e-08" ixz="4.94571e-08" iyy="0.01"
+               iyz="-4.29975e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437877996186 0.0700861001907 0.587138"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_foot_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_ankle_roll" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 -2.22044604925e-16"/>
+    <parent link="r_ankle_1"/>
+    <child link="r_ankle_2"/>
+    <limit effort="37.0" lower="-0.436332312999" upper="0.436332312999"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_foot">
+    <inertial>
+      <origin xyz="0.0336001 0.0053719 -0.001147"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.382866"/>
+      <inertia ixx="0.00120946" ixy="3.74585e-07" ixz="-5.78759e-05"
+               iyy="0.00141439" iyz="-7.80325e-06" izz="0.000273599"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.047209015 -0.070099992 -0.647438000286"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_sole_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.03 0.005 0.014" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <box size="0.16 0.072 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_foot_ft_sensor" type="fixed">
+    <origin xyz="-0.0035 0 -0.0605" rpy="3.14159265359 0 0"/>
+    <parent link="r_ankle_2"/>
+    <child link="r_foot"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole"/>
+  <joint name="r_sole_fixed_joint" type="fixed">
+    <origin xyz="0.0035 0 0.004" rpy="-3.14159265359 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hip_1">
+    <inertial>
+      <origin xyz="-0.0005108 0.0380923 -8.3e-05"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.919725"/>
+      <inertia ixx="0.000404539" ixy="1.18502e-06" ixz="-9.64514e-07"
+               iyy="0.000573315" iyz="-1.06028e-06" izz="0.000578982"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428515000001 -0.026 0.151913"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_hip_1_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_hip_pitch" type="revolute">
+    <origin xyz="0.0064515 -0.026 -0.119913" rpy="0 0 -3.14159265359"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="root_link"/>
+    <child link="l_hip_1"/>
+    <limit effort="55.5" lower="-0.785398163397" upper="2.33874119767"
+           velocity="5.1"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_hip_2">
+    <inertial>
+      <origin xyz="-0.0011063 1.73e-05 -0.044574"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.415987"/>
+      <inertia ixx="0.000475741" ixy="2.89355e-07" ixz="-6.72876e-08"
+               iyy="0.000279828" iyz="6.7417e-06" izz="0.000307828"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428514998093 -0.0701 0.151913"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_hip_2_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_hip_roll" type="revolute">
+    <origin xyz="0 0.0441 0" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 2.22044604925e-16"/>
+    <parent link="l_hip_1"/>
+    <child link="l_hip_2"/>
+    <limit effort="37.0" lower="-0.349065850399" upper="2.09439510239"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_hip_3">
+    <inertial>
+      <origin xyz="-0.0001229 -0.0002823 0.008718"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.126212"/>
+      <inertia ixx="0.01" ixy="2.67901e-07" ixz="-4.41463e-09" iyy="0.01"
+               iyz="3.32338e-08" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090614 0.0701000246 -0.226213"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_upper_thigh_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_leg_ft_sensor" type="fixed">
+    <origin xyz="-0.0008302 7.52e-05 -0.0743" rpy="3.14159265359 0 0"/>
+    <parent link="l_hip_2"/>
+    <child link="l_hip_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_upper_leg">
+    <inertial>
+      <origin xyz="0.0033869 0.0001018 -0.078916"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.8084"/>
+      <inertia ixx="0.00648512673084" ixy="-0.00012421121424"
+               ixz="-3.97399421479e-06" iyy="0.00146250529833"
+               iyz="-0.00013681806888" izz="0.00647619242046"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090614 -0.0701000246 0.240813"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_thigh_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_hip_yaw" type="revolute">
+    <origin xyz="0 0 0.0144" rpy="-3.14159265359 0 0"/>
+    <axis xyz="0.0 2.22044604925e-16 1.0"/>
+    <parent link="l_hip_3"/>
+    <child link="l_upper_leg"/>
+    <limit effort="37.0" lower="-1.3962634016" upper="1.3962634016" velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_upper_leg_back_contact"/>
+  <joint name="l_upper_leg_back_contact_fixed_joint" type="fixed">
+    <origin xyz="-0.0512567 0 0.0146" rpy="0 1.57079632679 0"/>
+    <parent link="l_upper_leg"/>
+    <child link="l_upper_leg_back_contact"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_upper_leg_dh_frame"/>
+  <joint name="l_upper_leg_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.145825" rpy="1.57079632679 0 0"/>
+    <parent link="l_upper_leg"/>
+    <child link="l_upper_leg_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_lower_leg">
+    <inertial>
+      <origin xyz="0.0009998 0.0034969 -0.088567"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.4724"/>
+      <inertia ixx="0.00423698606499" ixy="-0.000239615181423"
+               ixz="6.76166218238e-05" iyy="0.00152221313636"
+               iyz="-0.00023314283575" izz="0.00457007183207"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090614 -0.0701000248 0.386638"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_shank_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.005 0 -0.08"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+	    <box size="0.12 0.2 0.12" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_knee" type="revolute">
+    <origin xyz="0 0 -0.145825" rpy="0 0 0"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="l_upper_leg"/>
+    <child link="l_lower_leg"/>
+    <limit effort="37.0" lower="-2.16420827247" upper="0.0698131700798"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_ankle_1">
+    <inertial>
+      <origin xyz="0.0151531 0.000902 4.2e-05" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.6798"/>
+      <inertia ixx="0.000404474297345" ixy="-1.13226038781e-06"
+               ixz="3.04665105776e-05" iyy="0.00044788735407"
+               iyz="2.57265834141e-06" izz="0.000307603045377"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437090614 -0.0701000248 0.587138"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_ankle_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_ankle_pitch" type="revolute">
+    <origin xyz="0 0 -0.2005" rpy="0 0 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="l_lower_leg"/>
+    <child link="l_ankle_1"/>
+    <limit effort="37.0" lower="-0.610865238198" upper="0.610865238198"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_ankle_2">
+    <inertial>
+      <origin xyz="0.0011447 3.59999999998e-06 -0.03852"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.265122"/>
+      <inertia ixx="0.01" ixy="-4.74606e-08" ixz="4.94571e-08" iyy="0.01"
+               iyz="-4.29975e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0436816996186 -0.0701752001908 0.587138"
+              rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_foot_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_ankle_roll" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 2.22044604925e-16"/>
+    <parent link="l_ankle_1"/>
+    <child link="l_ankle_2"/>
+    <limit effort="37.0" lower="-0.436332312999" upper="0.436332312999"
+           velocity="7.64"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_foot">
+    <inertial>
+      <origin xyz="0.0336669 -0.0053735 -0.001164"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.382968"/>
+      <inertia ixx="0.00121242" ixy="-3.69533e-07" ixz="5.79273e-05"
+               iyy="0.00141712" iyz="-7.64972e-06" izz="0.000273846"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0472090612 0.0701000248 -0.647438000286"
+              rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_sole_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.03 -0.005 0.014" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <box size="0.16 0.072 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_foot_ft_sensor" type="fixed">
+    <origin xyz="-0.0035 0 -0.0605" rpy="3.14159265359 0 0"/>
+    <parent link="l_ankle_2"/>
+    <child link="l_foot"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole"/>
+  <joint name="l_sole_fixed_joint" type="fixed">
+    <origin xyz="0.0035 0 0.004" rpy="-3.14159265359 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="torso_1">
+    <inertial>
+      <origin xyz="0.0270921359 0.02914798 -0.0004398" rpy="0 0 0"/>
+      <mass value="0.67144"/>
+      <inertia ixx="0.00040911" ixy="-1.04522e-06" ixz="-1.02516e-06"
+               iyy="0.000384141" iyz="6.50708e-06" izz="0.000299445"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0270462998093 0.032 0.0364" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_lap_belt_1_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="torso_pitch" type="revolute">
+    <origin xyz="0 0.0270463 0" rpy="1.57079632679 0 -1.57079632679"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="root_link"/>
+    <child link="torso_1"/>
+    <limit effort="50000" lower="-0.349065850399" upper="1.2217304764"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="torso_2">
+    <inertial>
+      <origin xyz="-0.000113507809265 0.0361525 0.0570963" rpy="0 0 0"/>
+      <mass value="0.425685"/>
+      <inertia ixx="0.000829234" ixy="2.37006e-08" ixz="9.25231e-08"
+               iyy="0.000436517" iyz="-1.74814e-07" izz="0.000604802"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0.1433 0.0386531" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_lap_belt_2_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="torso_roll" type="revolute">
+    <origin xyz="0.0270462998093 0.032 -0.0573446" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="torso_1"/>
+    <child link="torso_2"/>
+    <limit effort="50000" lower="-0.523598775598" upper="0.523598775598"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="chest">
+    <inertial>
+      <origin xyz="0.000188619190735 0.073091 -0.0472381" rpy="0 0 0"/>
+      <mass value="7.638"/>
+      <inertia ixx="0.0430324878618" ixy="2.91075388804e-05" ixz="0.000181985229949"
+               iyy="0.0440835725548" iyz="-0.000429106409108"
+               izz="0.0260563249911"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0.0928 -0.024189" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_chest_bb_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0.065 -0.054" rpy="0 0 0"/>
+      <geometry>
+	    <box size="0.2 0.2 0.30" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_yaw" type="revolute">
+    <origin xyz="0 0.05 0.0628421" rpy="0 0 0"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="torso_2"/>
+    <child link="chest"/>
+    <limit effort="50000" lower="-0.872664625997" upper="0.872664625997"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_shoulder_1">
+    <inertial>
+      <origin xyz="-0.0122656014133 3.2e-05 -0.00321064290449" rpy="0 0 0"/>
+      <mass value="0.114862"/>
+      <inertia ixx="0.01" ixy="-1.65173e-08" ixz="-3.55626e-06" iyy="0.01"
+               iyz="-6.13337e-08" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0990079253076 0 -0.0265292487558" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_shoulder_1_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_shoulder_pitch" type="revolute">
+    <origin xyz="-0.120015999809 0.0928 0.0079693"
+            rpy="0 -0.523598883792 3.14159265359"/>
+    <axis xyz="-0.965925926173 0.0 0.258819275525"/>
+    <parent link="chest"/>
+    <child link="r_shoulder_1"/>
+    <limit effort="50000" lower="-1.66678943565" upper="0.174532925199"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_shoulder_2">
+    <inertial>
+      <origin xyz="-0.0214141709438 0.000271725272551 -0.0194402344535"
+              rpy="0 0 0"/>
+      <mass value="0.238162"/>
+      <inertia ixx="0.01" ixy="-1.12091e-07" ixz="1.02574e-05" iyy="0.01"
+               iyz="1.19785e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.106587808568 2.31914715418e-07 -0.0407392121175" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_shoulder_2_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_shoulder_roll" type="revolute">
+    <origin xyz="-0.00758046573227 0 0.0142102463639"
+            rpy="-0.270597611583 -0.252680154648 -1.50155680035"/>
+    <axis xyz="-0.258819 -2.77555756156e-17 -0.965926"/>
+    <parent link="r_shoulder_1"/>
+    <child link="r_shoulder_2"/>
+    <limit effort="50000" lower="0.0" upper="2.80648943721" velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_shoulder_3">
+    <inertial>
+      <origin xyz="-0.0267620766871 -6.99999999998e-06 0.0146999207713"
+              rpy="0 0 0"/>
+      <mass value="0.35913"/>
+      <inertia ixx="0.01" ixy="3.60361e-07" ixz="4.94445e-05" iyy="0.01"
+               iyz="2.65919e-07" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.131933879164 0 -0.0353515667647" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_upper_arm_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_shoulder_yaw" type="revolute">
+    <origin xyz="-0.0253460713232 2.32750427306e-07 -0.00538764806457"
+            rpy="-0.252689546175 0.0085186183214 0.067039889142"/>
+    <axis xyz="0.965925843882 -2.22044604925e-16 -0.258818979447"/>
+    <parent link="r_shoulder_2"/>
+    <child link="r_shoulder_3"/>
+    <limit effort="50000" lower="-0.645771823238" upper="1.3962634016"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_upper_arm">
+    <inertial>
+      <origin xyz="-0.006087 0.000126 0.0293121" rpy="0 1.30899700697 0"/>
+      <mass value="0.745104"/>
+      <inertia ixx="0.000509527" ixy="1.19292e-06" ixz="-1.17426e-05"
+               iyy="0.000668487" iyz="1.13363e-06" izz="0.000599254"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.015 0 -0.1933" rpy="0 1.30899700697 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_elbow_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_arm_ft_sensor" type="fixed">
+    <origin xyz="-0.0508973017665 0 0.0291670296206" rpy="0 -1.30899700697 0"/>
+    <parent link="r_shoulder_3"/>
+    <child link="r_upper_arm"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_elbow_1">
+    <inertial>
+      <origin xyz="-0.00673912932843 0.0188019 -0.00465769236154" rpy="0 0 0"/>
+      <mass value="0.267903"/>
+      <inertia ixx="0.01" ixy="7.36974e-06" ixz="-1.04536e-05" iyy="0.01"
+               iyz="3.92498e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.259390463317 0.0224999 -0.0850325886962" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_elbow_prosup_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_elbow" type="revolute">
+    <origin xyz="0 -0.0224999 0.07926" rpy="0 1.30899700697 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="r_upper_arm"/>
+    <child link="r_elbow_1"/>
+    <limit effort="50000" lower="0.261799387799" upper="1.85004900711"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_forearm">
+    <inertial>
+      <origin xyz="-0.0404391133886 -0.000328 0.00532733448387" rpy="0 0 0"/>
+      <mass value="0.6347"/>
+      <inertia ixx="0.000370044" ixy="-1.65419e-06" ixz="0.00010538"
+               iyy="0.000672279" iyz="1.1456e-06" izz="0.000553637"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.296886967375 0 -0.0795506015227" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_forearm_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.04 0 0"
+              rpy="0 0.3 0"/>
+      <geometry>
+	    <box size="0.13 0.08 0.1" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_prosup" type="revolute">
+    <origin xyz="-0.0384624299027 0.0224999 -0.00522316819403" rpy="0 0 0"/>
+    <axis xyz="0.965925843882 -2.22044604925e-16 -0.258818979447"/>
+    <parent link="r_elbow_1"/>
+    <child link="r_forearm"/>
+    <limit effort="50000" lower="-1.0471975512" upper="1.0471975512"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_forearm_dh_frame"/>
+  <joint name="r_forearm_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="-0.102871102373 7.00000000002e-06 0.0275642213111"
+            rpy="-0.261799319827 0 -1.57079632679"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_wrist_1">
+    <inertial>
+      <origin xyz="0.000986101955547 -0.001176 0.00410132736724" rpy="0 0 0"/>
+      <mass value="0.0362615"/>
+      <inertia ixx="0.01" ixy="-3.10462e-08" ixz="-9.44554e-07" iyy="0.01"
+               iyz="-1.59685e-07" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.400392176248 -7.00000000009e-06 -0.104748304516" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_wrist_pitch_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_wrist_pitch" type="revolute">
+    <origin xyz="-0.103505208873 7.00000000002e-06 0.0251977029936" rpy="0 0 0"/>
+    <axis xyz="0.258818979447 0.0 0.965925843882"/>
+    <parent link="r_forearm"/>
+    <child link="r_wrist_1"/>
+    <limit effort="50000" lower="-1.3962634016" upper="0.436332312999"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_hand">
+    <inertial>
+      <origin xyz="-0.064668163717 0.0056002 0.0226812940918" rpy="0 0 0"/>
+      <mass value="0.248289"/>
+      <inertia ixx="0.01" ixy="-2.3536e-06" ixz="3.61526e-05" iyy="0.01"
+               iyz="2.07146e-05" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.399758069749 0.0194929 -0.107114822834" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_r_hand_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="r_wrist_yaw" type="revolute">
+    <origin xyz="0.000634106499644 -0.0194999 0.00236651831751" rpy="0 0 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="r_wrist_1"/>
+    <child link="r_hand"/>
+    <limit effort="50000" lower="-0.349065850399" upper="0.436332312999"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="r_hand_dh_frame"/>
+  <joint name="r_hand_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="-0.0576542978428 -0.0055568 0.0136938323083"
+            rpy="-1.57079632679 -0.261799319827 3.14159265359"/>
+    <parent link="r_hand"/>
+    <child link="r_hand_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_shoulder_1">
+    <inertial>
+      <origin xyz="-0.008985 -3.3e-05 -0.0088998" rpy="0 0 0"/>
+      <mass value="0.114882"/>
+      <inertia ixx="0.01" ixy="-1.77064e-08" ixz="3.55951e-06" iyy="0.01"
+               iyz="6.57597e-08" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.120257482 0 -0.032223" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_shoulder_1_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_shoulder_pitch" type="revolute">
+    <origin xyz="0.120016000191 0.0928 0.0079693" rpy="0 0 0"/>
+    <axis xyz="0.965926 0.0 0.258819"/>
+    <parent link="chest"/>
+    <child link="l_shoulder_1"/>
+    <limit effort="50000" lower="-1.66678943565" upper="0.174532925199"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_shoulder_2">
+    <inertial>
+      <origin xyz="0.0214745951272 0.000268957899687 -0.0194107361535" rpy="0 0 0"/>
+      <mass value="0.238162"/>
+      <inertia ixx="0.01" ixy="1.19701e-07" ixz="-1.29687e-05" iyy="0.01"
+               iyz="1.20112e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.106586691581 1.10800934344e-07 -0.040743380771" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_shoulder_2_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_shoulder_roll" type="revolute">
+    <origin xyz="-0.013671 0 0.0085204"
+            rpy="0.270597317916 0.252680177542 -1.50155688559"/>
+    <axis xyz="-0.258819 2.77555756156e-17 0.965926"/>
+    <parent link="l_shoulder_1"/>
+    <child link="l_shoulder_2"/>
+    <limit effort="50000" lower="0.0" upper="2.80648943721" velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_shoulder_3">
+    <inertial>
+      <origin xyz="0.026798412222 -1.6e-05 0.0146956806177" rpy="0 0 0"/>
+      <mass value="0.35913"/>
+      <inertia ixx="0.01" ixy="-2.22441e-07" ixz="-4.95846e-05" iyy="0.01"
+               iyz="1.07538e-07" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.131901037685 0 -0.0353427669194" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_upper_arm_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_shoulder_yaw" type="revolute">
+    <origin xyz="0.0253143468312 1.11636438205e-07 -0.00540061656265"
+            rpy="-0.252689546175 -0.0085186183214 -0.067039889142"/>
+    <axis xyz="0.965925843882 2.22044604925e-16 0.258818979447"/>
+    <parent link="l_shoulder_2"/>
+    <child link="l_shoulder_3"/>
+    <limit effort="50000" lower="-0.645771823238" upper="1.3962634016"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_upper_arm">
+    <inertial>
+      <origin xyz="-0.006121 -0.000189 0.0293684"
+              rpy="0 -1.30899700697 -3.14159265359"/>
+      <mass value="0.746799"/>
+      <inertia ixx="0.000509731" ixy="-6.90767e-07" ixz="1.20048e-05"
+               iyy="0.00067086" iyz="3.11833e-06" izz="0.000601202"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.015 0 -0.1933" rpy="0 -1.30899700697 -3.14159265359"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_elbow_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_arm_ft_sensor" type="fixed">
+    <origin xyz="0.0509301432452 0 0.0291758294659"
+            rpy="0 -1.30899700697 3.14159265359"/>
+    <parent link="l_shoulder_3"/>
+    <child link="l_upper_arm"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_elbow_1">
+    <inertial>
+      <origin xyz="0.00673912932843 0.0303019 -0.00465769236154" rpy="0 0 0"/>
+      <mass value="0.267903"/>
+      <inertia ixx="0.01" ixy="-7.37159e-06" ixz="1.04505e-05" iyy="0.01"
+               iyz="3.9319e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.259390463317 0.0339999 -0.0850325886962" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_elbow_prosup_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_elbow" type="revolute">
+    <origin xyz="0 0.0339999 0.07926" rpy="0 -1.30899700697 -3.14159265359"/>
+    <axis xyz="2.22044604925e-16 -1.0 0.0"/>
+    <parent link="l_upper_arm"/>
+    <child link="l_elbow_1"/>
+    <limit effort="50000" lower="0.261799387799" upper="1.85004900711"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_forearm">
+    <inertial>
+      <origin xyz="0.0404511828823 -0.000686 0.00532363214379" rpy="0 0 0"/>
+      <mass value="0.636185"/>
+      <inertia ixx="0.000371447" ixy="4.34562e-06" ixz="-0.000105871"
+               iyy="0.000674229" iyz="4.05222e-06" izz="0.000557115"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.296886967375 0 -0.0795506015227" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_forearm_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.04 0 0"
+              rpy="0 -0.3 0"/>
+      <geometry>
+	    <box size="0.13 0.08 0.1" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_prosup" type="revolute">
+    <origin xyz="0.0384624299027 0.0339999 -0.00522316819403" rpy="0 0 0"/>
+    <axis xyz="0.965925843882 2.22044604925e-16 0.258818979447"/>
+    <parent link="l_elbow_1"/>
+    <child link="l_forearm"/>
+    <limit effort="50000" lower="-1.0471975512" upper="1.0471975512"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_forearm_dh_frame"/>
+  <joint name="l_forearm_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0.102871102373 7.00000000002e-06 0.0275642213111"
+            rpy="2.87979333376 0 1.57079632679"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_wrist_1">
+    <inertial>
+      <origin xyz="-0.000981313804428 -0.001178 0.00408345773913" rpy="0 0 0"/>
+      <mass value="0.0362152"/>
+      <inertia ixx="0.01" ixy="3.08362e-08" ixz="9.42153e-07" iyy="0.01"
+               iyz="-1.58924e-07" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.400314530555 -7.00000000009e-06 -0.105038082269" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_wrist_pitch_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_wrist_pitch" type="revolute">
+    <origin xyz="0.103427563179 7.00000000002e-06 0.0254874807467" rpy="0 0 0"/>
+    <axis xyz="0.258818979447 0.0 -0.965925843882"/>
+    <parent link="l_forearm"/>
+    <child link="l_wrist_1"/>
+    <limit effort="50000" lower="-1.3962634016" upper="0.436332312999"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_hand">
+    <inertial>
+      <origin xyz="0.0647680204057 0.0056304 0.0226602208449" rpy="0 0 0"/>
+      <mass value="0.247806"/>
+      <inertia ixx="0.01" ixy="2.96453e-06" ixz="-3.68906e-05" iyy="0.01"
+               iyz="2.06885e-05" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.399680424055 0.0194929 -0.107404600587" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_l_hand_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="l_wrist_yaw" type="revolute">
+    <origin xyz="-0.000634106499644 -0.0194999 0.00236651831751" rpy="0 0 0"/>
+    <axis xyz="-2.22044604925e-16 1.0 0.0"/>
+    <parent link="l_wrist_1"/>
+    <child link="l_hand"/>
+    <limit effort="50000" lower="-0.349065850399" upper="0.436332312999"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="l_hand_dh_frame"/>
+  <joint name="l_hand_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0.0576542978428 -0.0055568 0.0136938323083"
+            rpy="-1.57079632679 -0.261799319827 0"/>
+    <parent link="l_hand"/>
+    <child link="l_hand_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="neck_1">
+    <inertial>
+      <origin xyz="0.0143705608 0.006567 -0.0063842" rpy="0 0 0"/>
+      <mass value="0.125793"/>
+      <inertia ixx="0.01" ixy="8.09156e-08" ixz="-3.74998e-08" iyy="0.01"
+               iyz="9.39717e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0142999998093 -0.079997 -0.0295008" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_neck_1_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="neck_pitch" type="revolute">
+    <origin xyz="-0.0142999998093 0.172797 0.0053118" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="chest"/>
+    <child link="neck_1"/>
+    <limit effort="50000" lower="-0.698131700798" upper="0.383972435439"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="neck_2">
+    <inertial>
+      <origin xyz="-8.8573009265e-05 0.035225 -0.01954527" rpy="0 0 0"/>
+      <mass value="0.177087"/>
+      <inertia ixx="0.01" ixy="-5.25591e-07" ixz="4.68307e-07" iyy="0.01"
+               iyz="9.81476e-06" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.089497 -0.05030077" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_neck_2_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="neck_roll" type="revolute">
+    <origin xyz="0.0142999998093 0.0095 0.02079997" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="neck_1"/>
+    <child link="neck_2"/>
+    <limit effort="50000" lower="-0.349065850399" upper="0.349065850399"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="head">
+    <inertial>
+      <origin xyz="-0.000574157809265 0.113511 -0.0075392" rpy="0 0 0"/>
+      <mass value="1.50691"/>
+      <inertia ixx="0.00680478" ixy="-1.60267e-05" ixz="7.28166e-05"
+               iyy="0.00634736" iyz="0.000292091" izz="0.00478116"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.067153 -0.0295008" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="file://meshes/simmechanics/sim_sea_2-5_head_prt-binary.stl"
+              scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0.13 -0.016"
+              rpy="0 0 0"/>
+      <geometry>
+	    <box size="0.18 0.18 0.215" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_yaw" type="revolute">
+    <origin xyz="0 -0.022344 -0.02079997" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="neck_2"/>
+    <child link="head"/>
+    <limit effort="50000" lower="-0.872664625997" upper="0.872664625997"
+           velocity="50000"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+  <link name="base_link"/>
+  <joint name="base_fixed_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 -0 0"/>
+    <axis xyz="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="root_link"/>
+  </joint>
+  <link name="l_foot_dh_frame"/>
+  <joint name="l_foot_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0.0 0 0.004" rpy="0 1.5708 0"/>
+    <axis xyz="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_foot_dh_frame"/>
+  </joint>
+  <link name="r_foot_dh_frame"/>
+  <joint name="r_foot_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0.0 0 0.004" rpy="0 1.5708 0"/>
+    <axis xyz="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_foot_dh_frame"/>
+  </joint>
+  <gazebo reference="r_arm_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="l_arm_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="r_leg_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="l_leg_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="r_foot_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="l_foot_ft_sensor">
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <!-- For compatibility with SDFormat < 4.4 -->
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+  <gazebo reference="l_foot">
+    <collision>
+      <surface>
+        <bounce>
+          <restitution_coefficient>0</restitution_coefficient>
+          <threshold>100000</threshold>
+        </bounce>
+      </surface>
+      <max_contacts>4</max_contacts>
+    </collision>
+  </gazebo>
+  <gazebo reference="r_foot">
+    <collision>
+      <surface>
+        <bounce>
+          <restitution_coefficient>0</restitution_coefficient>
+          <threshold>100000</threshold>
+        </bounce>
+      </surface>
+      <max_contacts>4</max_contacts>
+    </collision>
+  </gazebo>
+  <gazebo reference="r_hip_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_hip_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_hip_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_knee">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_ankle_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_ankle_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_hip_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_hip_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_hip_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_knee">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_ankle_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_ankle_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="torso_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="torso_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="torso_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_shoulder_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_shoulder_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_shoulder_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_elbow">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_wrist_prosup">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_wrist_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="r_wrist_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_shoulder_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_shoulder_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_shoulder_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_elbow">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_wrist_prosup">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_wrist_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="l_wrist_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="neck_pitch">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="neck_roll">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo reference="neck_yaw">
+    <implicitSpringDamper>1</implicitSpringDamper>
+  </gazebo>
+  <gazebo>
+    <pose>0.0 0.0 0.63 0.0 0.0 3.14</pose>
+  </gazebo>
+  <gazebo reference="root_link">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="torso_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="torso_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="chest">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="neck_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="neck_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="head">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_hip_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_hip_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_hip_3">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_upper_leg">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_lower_leg">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_ankle_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_ankle_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_foot">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_shoulder_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_shoulder_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_shoulder_3">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_upper_arm">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_elbow_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_forearm">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_wrist_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="l_hand">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_hip_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_hip_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_hip_3">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_upper_leg">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_lower_leg">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_ankle_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_ankle_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_foot">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_shoulder_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_shoulder_2">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_shoulder_3">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_upper_arm">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_elbow_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_forearm">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_wrist_1">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+  <gazebo reference="r_hand">
+    <visual>
+      <material>
+        <diffuse>1 1 1 1</diffuse>
+      </material>
+    </visual>
+  </gazebo>
+
+</robot>

--- a/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/model.config
+++ b/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/model.config
@@ -11,6 +11,6 @@
     </author>
 
     <description>
-        Model of the iCub humanoid robot, with simplified collision meshes. For more information check icub.org.
+        Model of the iCub humanoid robot, with simplified collision meshes. For more information check https://github.com/dic-iit/gym-ignition-models.
     </description>
 </model>

--- a/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/model.config
+++ b/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+    <name>iCubGazeboSimpleCollisionsV2_5</name>
+    <version>1.0</version>
+    <sdf>icub_simple_collisions.urdf</sdf>
+
+    <author>
+        <name>Paolo Maria Viceconte</name>
+        <email>paolo.viceconte@iit.it</email>
+    </author>
+
+    <description>
+        Model of the iCub humanoid robot, with simplified collision meshes. For more information check icub.org.
+    </description>
+</model>

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ class BuildExtension(build_ext):
     # Dict that defines the folders to copy during the build process
     FROM_ORIG_TO_DEST = {
         f"{SHARED_MESH_DIR}/iCubGazeboV2_5": "iCubGazeboV2_5/meshes",
+        f"{SHARED_MESH_DIR}/iCubGazeboV2_5": "iCubGazeboSimpleCollisionsV2_5/meshes",
     }
 
     def run(self) -> None:


### PR DESCRIPTION
This model is obtained by manually simplifying the collision meshes of the iCubGazeboV2_5 model. 

In particular, the collision meshes of all the iCub links (apart the feet) have been deleted. Simplified boxes for the forearms, lower legs, chest, root link and head have been added. The collision meshes of the feet are kept unchanged. 

![icub_meshes_2](https://user-images.githubusercontent.com/41757826/76681969-3d1fa400-65f8-11ea-880a-58d45b781390.png)
