### PR TITLE
Configure environment variables with a helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Only GNU/Linux distributions are currently supported.
 
 ### Configuration
 
+#### Standalone usage
+
 If you use Ignition Gazebo, you need to execute the following commands (from outside the directory where you cloned this repository):
 
 ```sh
@@ -52,6 +54,18 @@ export SDF_PATH=$PKG_DIR:SDF_PATH
 If you want to make this change persistent, add the lines above to your `~/.bashrc`.
 
 **Note:** waiting an [upstream fix](https://bitbucket.org/osrf/sdformat/issues/227/error-loading-meshes-from-a-relative), you also need to add to the `IGN_FILE_PATH` environment variable all the directories that contain model's meshes.
+
+#### Python usage
+
+If you're using the models from a Python program, we provide a helper function that updates the environment.
+Use the following code:
+
+```python
+import gym_ignition_models
+gym_ignition_models.setup_environment()
+```
+
+If you inspect the content of `os.environ` after this call, you'll find the environment variables already exported.
 
 ### Usage
 

--- a/gym_ignition_models/__init__.py
+++ b/gym_ignition_models/__init__.py
@@ -4,6 +4,7 @@
 
 import os
 from typing import List
+from pathlib import Path
 
 
 def get_models_path() -> str:
@@ -80,3 +81,37 @@ def get_model_string(robot_name: str) -> str:
         string = f.read()
 
     return string
+
+
+def setup_environment() -> None:
+    """
+    Configure the environment variables.
+    """
+
+    models_path = Path(get_models_path())
+
+    if not models_path.exists():
+        raise NotADirectoryError(f"Failed to find path '{models_path}'")
+
+    # Setup the environment to find the models
+    if "SDF_PATH" in os.environ:
+        os.environ["SDF_PATH"] += f":{models_path}"
+    else:
+        os.environ["SDF_PATH"] = f"{models_path}"
+
+    # Models with mesh files
+    # Workaround for https://github.com/osrf/sdformat/issues/227
+    models_with_mesh = ["panda", "iCubGazeboV2_5", "iCubGazeboSimpleCollisionsV2_5"]
+
+    # Setup the environment to find the mesh files
+    for model in models_with_mesh:
+
+        model_path = Path(get_models_path()) / model
+
+        if not model_path.exists():
+            raise NotADirectoryError(f"Failed to find path '{model_path}'")
+
+        if "IGN_FILE_PATH" in os.environ:
+            os.environ["IGN_FILE_PATH"] += f':{model_path}'
+        else:
+            os.environ["IGN_FILE_PATH"] = f'{model_path}'


### PR DESCRIPTION
As an alternative of manually exporting the environment variables, this PR introduces a new method:

```python
import gym_ignition_models
gym_ignition_models.setup_environment()
```

Exporting the `IGN_FILE_PATH` variable is still necessary waiting for https://github.com/osrf/sdformat/issues/227.